### PR TITLE
Circular reference issue fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Spelling in container PHPDoc
 - Switched from coveralls to scrutinizer
 - Mistake in .gitattributes file
+- Fixed detection of circular references
 
 ### Removed
 - Unnecessary use declaration in container test

--- a/test/ContainerTest.php
+++ b/test/ContainerTest.php
@@ -140,6 +140,12 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
             'foo' => [
                 'class' => MockService::class,
                 'arguments' => [
+                    new ServiceReference('bar'),
+                ],
+            ],
+            'bar' => [
+                'class' => MockService::class,
+                'arguments' => [
                     new ServiceReference('foo'),
                 ],
             ],


### PR DESCRIPTION
The first commit shows the failing test.

Previously the only protection against circular references was that the container detected if a service depended on itself. There was no protection for A depends on B and B also depends on A.

The fix for this is to add a 'lock' parameter that detected if the container was in the process of trying to make a service.
